### PR TITLE
Gateway lock enhancement, eslint and formatting tweaks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,14 +29,19 @@
     "strict": [
       2,
       "global"
-    ]
+    ],
+    "max-len": "warn",
+    "camelcase": "warn",
+    "prefer-const": "warn",
+    "no-await-in-loop": "warn"
   },
   "settings": {
     "import/core-modules": [
       "@grpc/grpc-js",
       "@grpc/proto-loader",
       "grpc",
-      "pm2"
+      "pm2",
+      "ws"
     ]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,6 +37,7 @@
   },
   "settings": {
     "import/core-modules": [
+      "axios",
       "@grpc/grpc-js",
       "@grpc/proto-loader",
       "grpc",

--- a/examples/rpc_clients.js
+++ b/examples/rpc_clients.js
@@ -10,31 +10,85 @@
 
   const token = 'myBotToken'; // https://discordapp.com/developers/applications/
   const gateway = new Gateway(token);
-  /* Connect to a server and set the lock to 5000 milliseconds (5 seconds). */
-  gateway.addIdentifyLockService({ duration: 5000, allowFallback: true });
   /*
-    Provide a host/port to point to services to point to a different server than default.
-    gateway.addIdentifyLockService({
-        duration: 5000,
-        host: 127.0.0.1,
-        port: 55051
-    });
+    Connect to a server and set the main lock duration to 5000 milliseconds (5 seconds).
+    When acquiring the lock, it will remaining locked for the duration.
+    The main lock will not be unlocked by this client or Paracord.
+    `allowFallback` will ignore the lock if the client cannot reach the server. defaults to `true`.
   */
-  /*
-    For the addIdentifyLockService, provide two host/ports to set up two locks.
-    gateway.addIdentifyLockService({
-        duration: 5000,
-        host: 127.0.0.1,
-        port: 55051
-    },{
-        duration: 10000,
-        host: 127.0.0.1,
-        port: 55052
-    });
-   */
-
+  gateway.addIdentifyLockServices({ duration: 5000, allowFallback: true });
   gateway.login();
 }
+
+{
+  const { Gateway } = require('paracord');
+
+  const token = 'myBotToken'; // https://discordapp.com/developers/applications/
+  const gateway = new Gateway(token);
+  /*
+    Additional locks can be passed and will be acquired in succession when identifying.
+    The main lock will be acquired last since it will not be unlocked by Paracord.
+  */
+  gateway.addIdentifyLockServices(
+    {
+      // acquired third
+      duration: 5000, // using default host:port (127.0.0.1:50051)
+    },
+    {
+      // acquired first
+      host: '127.0.0.1', port: 50052, duration: 10000,
+    },
+    {
+      // acquired second
+      host: '127.0.0.1', port: 50053, duration: 20000,
+    },
+  );
+  gateway.login();
+}
+
+{
+  const { Gateway } = require('paracord');
+
+  const token = 'myBotToken'; // https://discordapp.com/developers/applications/
+  const gateway = new Gateway(token);
+  /*
+    Pass in `null` as the first parameter to not set the main lock.
+  */
+  gateway.addIdentifyLockServices(
+    null,
+    {
+      // only lock
+      host: '127.0.0.1', port: 50052, duration: 10000,
+    },
+
+  );
+  gateway.login();
+}
+
+/*
+  Provide a host/port to point to services to point to a different server than default.
+  gateway.addIdentifyLockService({
+      duration: 5000,
+      host: '127.0.0.1', // default host
+      port: 50051 // default port
+  });
+*/
+
+/*
+  For the addIdentifyLockService, provide additional locks as parameters. They will be acquired in order defined.
+  gateway.addIdentifyLockService(
+    {
+      duration: 5000,
+      host: '127.0.0.1',
+      port: 50051,
+    },
+    {
+      duration: 10000,
+      host: '127.0.0.1',
+      port: 50052,
+    },
+  );
+  */
 
 /*
  ************************
@@ -47,6 +101,7 @@
   const token = 'myBotToken'; // https://discordapp.com/developers/applications/
   const api = new Api(token);
 
+  /*  `allowFallback` defaults to `true`. */
   api.addRateLimitService({ allowFallback: true }); // Only one of these services may be added to a client.
   // api.addRequestService();
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict';
 
 module.exports = {
   Gateway: require('./src/clients/Gateway/Gateway'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "paracord",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8,6 +8,7 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
       "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "dev": true,
       "requires": {
         "@babel/highlight": "^7.0.0"
       }
@@ -57,6 +58,7 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
       "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -498,13 +500,13 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
       "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
-      "optional": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
       "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
-      "optional": true
+      "dev": true
     },
     "agent-base": {
       "version": "4.3.0",
@@ -519,7 +521,7 @@
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
       "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -552,7 +554,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
       "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "type-fest": "^0.8.1"
       }
@@ -643,7 +645,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
       "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0",
@@ -654,7 +656,7 @@
           "version": "1.17.4",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
           "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -673,7 +675,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -684,19 +686,19 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
           "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "optional": true
+          "dev": true
         },
         "is-callable": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
           "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-          "optional": true
+          "dev": true
         },
         "is-regex": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
           "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "has": "^1.0.3"
           }
@@ -705,13 +707,13 @@
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
           "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-          "optional": true
+          "dev": true
         },
         "string.prototype.trimleft": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
           "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
             "function-bind": "^1.1.1"
@@ -721,7 +723,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
           "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
             "function-bind": "^1.1.1"
@@ -739,7 +741,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
       "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
@@ -749,7 +751,7 @@
           "version": "1.17.4",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
           "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -768,7 +770,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -779,19 +781,19 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
           "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "optional": true
+          "dev": true
         },
         "is-callable": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
           "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-          "optional": true
+          "dev": true
         },
         "is-regex": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
           "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "has": "^1.0.3"
           }
@@ -800,13 +802,13 @@
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
           "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-          "optional": true
+          "dev": true
         },
         "string.prototype.trimleft": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
           "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
             "function-bind": "^1.1.1"
@@ -816,7 +818,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
           "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
             "function-bind": "^1.1.1"
@@ -850,7 +852,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-      "optional": true
+      "dev": true
     },
     "async": {
       "version": "2.6.3",
@@ -870,7 +872,8 @@
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "optional": true
     },
     "async-listener": {
       "version": "0.6.10",
@@ -1082,7 +1085,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "optional": true
+      "dev": true
     },
     "camelcase": {
       "version": "5.3.1",
@@ -1114,7 +1117,7 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "optional": true
+      "dev": true
     },
     "charm": {
       "version": "0.1.2",
@@ -1169,7 +1172,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "restore-cursor": "^3.1.0"
       }
@@ -1229,7 +1232,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-      "optional": true
+      "dev": true
     },
     "cliui": {
       "version": "4.1.0",
@@ -1310,13 +1313,13 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
       "integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
-      "optional": true
+      "dev": true
     },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
-      "optional": true
+      "dev": true
     },
     "continuation-local-storage": {
       "version": "3.2.1",
@@ -1375,6 +1378,7 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -1423,8 +1427,7 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "optional": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "default-require-extensions": {
       "version": "2.0.0",
@@ -1439,6 +1442,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -1519,7 +1523,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "esutils": "^2.0.2"
       }
@@ -1536,7 +1540,8 @@
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
     },
     "end-of-stream": {
       "version": "1.4.2",
@@ -1551,6 +1556,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -1641,7 +1647,7 @@
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
       "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -1686,13 +1692,13 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "optional": true
+          "dev": true
         },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -1701,7 +1707,7 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
           "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
           }
@@ -1710,7 +1716,7 @@
           "version": "12.3.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
           "integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "type-fest": "^0.8.1"
           }
@@ -1719,13 +1725,13 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "optional": true
+          "dev": true
         },
         "optionator": {
           "version": "0.8.3",
           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
           "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "deep-is": "~0.1.3",
             "fast-levenshtein": "~2.0.6",
@@ -1739,13 +1745,13 @@
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "optional": true
+          "dev": true
         },
         "strip-ansi": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -1754,7 +1760,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
           "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -1762,7 +1768,7 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.0.0.tgz",
       "integrity": "sha512-2IDHobw97upExLmsebhtfoD3NAKhV4H0CJWP3Uprd/uk+cHuWYOczPVxQ8PxLFUAw7o3Th1RAU8u1DoUpr+cMA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "confusing-browser-globals": "^1.0.7",
         "object.assign": "^4.1.0",
@@ -1773,7 +1779,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
       "integrity": "sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "debug": "^2.6.9",
         "resolve": "^1.13.1"
@@ -1783,7 +1789,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -1792,7 +1798,7 @@
           "version": "1.15.1",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
           "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
           }
@@ -1803,7 +1809,7 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.2.tgz",
       "integrity": "sha512-LGScZ/JSlqGKiT8OC+cYRxseMjyqt6QO54nl281CK93unD89ijSeRV6An8Ci/2nvWVKe8K/Tqdm75RQoIOCr+Q==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "debug": "^2.6.9",
         "pkg-dir": "^2.0.0"
@@ -1813,7 +1819,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -1822,7 +1828,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "optional": true,
+          "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
           }
@@ -1831,7 +1837,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "optional": true,
+          "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
             "path-exists": "^3.0.0"
@@ -1841,7 +1847,7 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "p-try": "^1.0.0"
           }
@@ -1850,7 +1856,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "optional": true,
+          "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
           }
@@ -1859,13 +1865,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "optional": true
+          "dev": true
         },
         "pkg-dir": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
           "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-          "optional": true,
+          "dev": true,
           "requires": {
             "find-up": "^2.1.0"
           }
@@ -1876,7 +1882,7 @@
       "version": "2.20.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.1.tgz",
       "integrity": "sha512-qQHgFOTjguR+LnYRoToeZWT62XM55MBVXObHM6SKFd1VzDcX/vqT1kAz8ssqigh5eMj8qXcRoXXGZpPP6RfdCw==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
         "array.prototype.flat": "^1.2.1",
@@ -1896,7 +1902,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -1905,7 +1911,7 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "optional": true,
+          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "isarray": "^1.0.0"
@@ -1915,7 +1921,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "optional": true,
+          "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
           }
@@ -1924,13 +1930,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "optional": true
+          "dev": true
         },
         "load-json-file": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "optional": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "parse-json": "^2.2.0",
@@ -1942,7 +1948,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "optional": true,
+          "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
             "path-exists": "^3.0.0"
@@ -1952,7 +1958,7 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "p-try": "^1.0.0"
           }
@@ -1961,7 +1967,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "optional": true,
+          "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
           }
@@ -1970,13 +1976,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "optional": true
+          "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "optional": true,
+          "dev": true,
           "requires": {
             "error-ex": "^1.2.0"
           }
@@ -1985,7 +1991,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "optional": true,
+          "dev": true,
           "requires": {
             "pify": "^2.0.0"
           }
@@ -1994,13 +2000,13 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "optional": true
+          "dev": true
         },
         "read-pkg": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "optional": true,
+          "dev": true,
           "requires": {
             "load-json-file": "^2.0.0",
             "normalize-package-data": "^2.3.2",
@@ -2011,7 +2017,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "optional": true,
+          "dev": true,
           "requires": {
             "find-up": "^2.0.0",
             "read-pkg": "^2.0.0"
@@ -2023,7 +2029,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
       "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
@@ -2033,7 +2039,7 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
       "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
       }
@@ -2042,13 +2048,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
       "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
-      "optional": true
+      "dev": true
     },
     "espree": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
       "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "acorn": "^7.1.0",
         "acorn-jsx": "^5.1.0",
@@ -2064,7 +2070,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
       "integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "estraverse": "^4.0.0"
       }
@@ -2073,7 +2079,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "estraverse": "^4.1.0"
       }
@@ -2081,8 +2087,7 @@
     "estraverse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "optional": true
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
     },
     "esutils": {
       "version": "2.0.3",
@@ -2185,7 +2190,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
@@ -2261,19 +2266,18 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
       "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
-      "optional": true
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "optional": true
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "optional": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fclone": {
       "version": "1.0.11",
@@ -2285,7 +2289,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
@@ -2294,7 +2298,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
       "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "flat-cache": "^2.0.1"
       }
@@ -2361,7 +2365,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
       "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "flatted": "^2.0.0",
         "rimraf": "2.6.3",
@@ -2372,7 +2376,7 @@
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -2383,7 +2387,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
-      "optional": true
+      "dev": true
     },
     "follow-redirects": {
       "version": "1.5.10",
@@ -2952,13 +2956,14 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "optional": true
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -3578,6 +3583,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -3607,7 +3613,8 @@
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -3665,7 +3672,8 @@
     "hosted-git-info": {
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ=="
+      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+      "dev": true
     },
     "http-errors": {
       "version": "1.7.3",
@@ -3704,7 +3712,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "optional": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -3713,13 +3720,13 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-      "optional": true
+      "dev": true
     },
     "import-fresh": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
       "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -3728,7 +3735,8 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -3754,7 +3762,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
       "integrity": "sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^2.4.2",
@@ -3775,25 +3783,25 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "optional": true
+          "dev": true
         },
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "optional": true
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "optional": true
+          "dev": true
         },
         "string-width": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -3804,7 +3812,7 @@
               "version": "6.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
               "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-              "optional": true,
+              "dev": true,
               "requires": {
                 "ansi-regex": "^5.0.0"
               }
@@ -3815,7 +3823,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           },
@@ -3824,7 +3832,7 @@
               "version": "4.1.0",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
               "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-              "optional": true
+              "dev": true
             }
           }
         }
@@ -3877,7 +3885,8 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -3928,7 +3937,8 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -3958,19 +3968,18 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "optional": true
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
     },
     "is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-      "optional": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -4014,7 +4023,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "optional": true
+      "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -4035,12 +4044,13 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
       "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
-      "optional": true
+      "dev": true
     },
     "is-symbol": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.0"
       }
@@ -4059,7 +4069,8 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isobject": {
       "version": "3.0.1",
@@ -4187,12 +4198,14 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -4214,13 +4227,13 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "optional": true
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-      "optional": true
+      "dev": true
     },
     "just-extend": {
       "version": "4.0.2",
@@ -4253,7 +4266,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "optional": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -4459,7 +4471,8 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -4656,8 +4669,7 @@
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "optional": true
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "nan": {
       "version": "2.14.0",
@@ -4688,7 +4700,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "optional": true
+      "dev": true
     },
     "needle": {
       "version": "2.3.2",
@@ -4739,7 +4751,8 @@
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
     },
     "nise": {
       "version": "1.5.2",
@@ -4768,6 +4781,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
@@ -4892,7 +4906,8 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -4907,6 +4922,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -4918,7 +4934,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
       "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1",
@@ -4930,7 +4946,7 @@
           "version": "1.17.4",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
           "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -4949,7 +4965,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -4960,19 +4976,19 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
           "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "optional": true
+          "dev": true
         },
         "is-callable": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
           "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-          "optional": true
+          "dev": true
         },
         "is-regex": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
           "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "has": "^1.0.3"
           }
@@ -4981,13 +4997,13 @@
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
           "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-          "optional": true
+          "dev": true
         },
         "string.prototype.trimleft": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
           "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
             "function-bind": "^1.1.1"
@@ -4997,7 +5013,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
           "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
             "function-bind": "^1.1.1"
@@ -5028,7 +5044,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
       "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1",
@@ -5040,7 +5056,7 @@
           "version": "1.17.4",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
           "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -5059,7 +5075,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -5070,19 +5086,19 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
           "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "optional": true
+          "dev": true
         },
         "is-callable": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
           "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-          "optional": true
+          "dev": true
         },
         "is-regex": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
           "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "has": "^1.0.3"
           }
@@ -5091,13 +5107,13 @@
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
           "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-          "optional": true
+          "dev": true
         },
         "string.prototype.trimleft": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
           "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
             "function-bind": "^1.1.1"
@@ -5107,7 +5123,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
           "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "define-properties": "^1.1.3",
             "function-bind": "^1.1.1"
@@ -5127,7 +5143,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
       "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -5183,7 +5199,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "optional": true
+      "dev": true
     },
     "p-defer": {
       "version": "1.0.0",
@@ -5295,7 +5311,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "callsites": "^3.0.0"
       }
@@ -5325,7 +5341,8 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -5335,7 +5352,8 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
@@ -5494,8 +5512,7 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "optional": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -5507,7 +5524,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "optional": true
+      "dev": true
     },
     "promptly": {
       "version": "2.2.0",
@@ -5703,7 +5720,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "optional": true
+      "dev": true
     },
     "raw-body": {
       "version": "2.4.1",
@@ -5813,7 +5830,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
-      "optional": true
+      "dev": true
     },
     "release-zalgo": {
       "version": "1.0.0",
@@ -5893,7 +5910,8 @@
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -5905,7 +5923,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -5930,7 +5948,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "optional": true,
+      "dev": true,
       "requires": {
         "is-promise": "^2.1.0"
       }
@@ -5939,7 +5957,7 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
       "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -5961,8 +5979,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "optional": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sax": {
       "version": "1.2.4",
@@ -6014,6 +6031,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -6021,7 +6039,8 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
     },
     "shelljs": {
       "version": "0.8.3",
@@ -6075,7 +6094,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
       "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
@@ -6301,6 +6320,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
       "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -6309,12 +6329,14 @@
     "spdx-exceptions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -6323,7 +6345,8 @@
     "spdx-license-ids": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "dev": true
     },
     "split-string": {
       "version": "3.1.0",
@@ -6414,7 +6437,8 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -6441,7 +6465,7 @@
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
       "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "ajv": "^6.10.2",
         "lodash": "^4.17.14",
@@ -6453,13 +6477,13 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "optional": true
+          "dev": true
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -6470,7 +6494,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "optional": true,
+          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -6493,13 +6517,13 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "optional": true
+      "dev": true
     },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "optional": true
+      "dev": true
     },
     "thunkify": {
       "version": "2.1.2",
@@ -6511,7 +6535,7 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
@@ -6579,8 +6603,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "optional": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tv4": {
       "version": "1.3.0",
@@ -6592,7 +6615,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "optional": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -6607,7 +6629,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "optional": true
+      "dev": true
     },
     "uglify-js": {
       "version": "3.7.6",
@@ -6709,7 +6731,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -6740,13 +6762,13 @@
     "v8-compile-cache": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
-      "optional": true
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -6783,6 +6805,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -6811,8 +6834,7 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "optional": true
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "wordwrap": {
       "version": "0.0.3",
@@ -6871,7 +6893,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
       "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
       }
@@ -6888,12 +6910,9 @@
       }
     },
     "ws": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.2.tgz",
-      "integrity": "sha512-gftXq3XI81cJCgkUiAVixA0raD9IVmXqsylCrjRygw4+UOOGzPoxnQ6r/CnVL9i+mDncJo94tSkyrtuuQVBmrg==",
-      "requires": {
-        "async-limiter": "^1.0.0"
-      }
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A=="
     },
     "xregexp": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "axios": "^0.19.0",
-    "ws": "^7.1.2"
+    "ws": "^7.2.1"
   },
   "devDependencies": {
     "mocha": "^6.2.1",

--- a/src/clients/Api/Api.js
+++ b/src/clients/Api/Api.js
@@ -33,7 +33,7 @@ module.exports = class Api {
     this.rateLimitCache;
     /** @type {RequestQueue} Rate limited requests queue. For use when not using rpc; or in fallback, */
     this.requestQueue;
-    /** @type {NodeJS.Timer} Interval for processing ratelimited requests on the queue. */
+    /** @type {NodeJS.Timer} Interval for processing rate limited requests on the queue. */
     this.requestQueueProcessInterval;
 
     /** @type {RequestService} When using Rpc, the service through which to pass requests to the server. */
@@ -101,7 +101,7 @@ module.exports = class Api {
       ...(this.requestOptions || {}),
     });
 
-    /** @type {WrappedRequest} `axios.request()` decorated with ratelimit handling. */
+    /** @type {WrappedRequest} `axios.request()` decorated with rate limit handling. */
     this.wrappedRequest = this.rateLimitCache.wrapRequest(instance.request);
   }
 
@@ -165,8 +165,10 @@ module.exports = class Api {
     this.rpcRequestService = new RequestService(serverOptions || {});
     this.allowFallback = serverOptions.allowFallback;
 
-    const message = `Rpc service created for sending requests remotely. Connected to: ${this.rpcRequestService.target}`;
-    this.log('INFO', message);
+    {
+      const message = `Rpc service created for sending requests remotely. Connected to: ${this.rpcRequestService.target}`;
+      this.log('INFO', message);
+    }
 
     if (!this.allowFallback) {
       const message = '`allowFallback` option is not true. Requests will fail when unable to connect to the Rpc server.';
@@ -192,8 +194,10 @@ module.exports = class Api {
     this.rpcRateLimitService = new RateLimitService(serverOptions || {});
     this.allowFallback = serverOptions.allowFallback;
 
-    const message = `Rpc service created for handling rate limits remotely. Connected to: ${this.rpcRateLimitService.target}`;
-    this.log('INFO', message);
+    {
+      const message = `Rpc service created for handling rate limits remotely. Connected to: ${this.rpcRateLimitService.target}`;
+      this.log('INFO', message);
+    }
 
     if (!this.allowFallback) {
       const message = '`allowFallback` option is not true. Requests will fail when unable to connect to the Rpc server.';
@@ -208,7 +212,7 @@ module.exports = class Api {
    */
 
   /**
-   * Starts the request rate limit queue processesing.
+   * Starts the request rate limit queue processing.
    *
    * @param {number} [interval=1e3] Time between checks in ms.
    */
@@ -224,7 +228,7 @@ module.exports = class Api {
     }
   }
 
-  /** Stops the request rate limit queue processesing. */
+  /** Stops the request rate limit queue processing. */
   stopQueue() {
     this.log('INFO', 'Stopping request queue.');
     clearInterval(this.requestQueueProcessInterval);
@@ -433,7 +437,7 @@ module.exports = class Api {
   }
 
   /**
-   * Updates the rate limit state and enqueues the request.
+   * Updates the rate limit state and queues the request.
    * @private
    *
    * @param {RateLimitHeaders} headers Response headers.
@@ -448,18 +452,18 @@ module.exports = class Api {
       message = `Request rate limited: ${request.method} ${request.url}`;
     }
 
-    this.log('DBEUG', message, rateLimitHeaders);
+    this.log('DEBUG', message, rateLimitHeaders);
 
     this.updateRateLimitCache(request);
     return this.enqueueRequest(request);
   }
 
   /**
-   * Puts the Api Request onto the queue to be executed when the ratelimit has reset.
+   * Puts the Api Request onto the queue to be executed when the rate limit has reset.
    * @private
    *
    * @param {import("./structures/Request")} request The Api Request to queue.
-   * @returns {Promise} Resolves as the reponsse to the request.
+   * @returns {Promise} Resolves as the response to the request.
    */
   enqueueRequest(request) {
     // request.timeout = new Date().getTime() + timeout;

--- a/src/clients/Api/structures/RateLimit.js
+++ b/src/clients/Api/structures/RateLimit.js
@@ -61,7 +61,7 @@ module.exports = class RateLimit {
     this.remaining = this.limit;
   }
 
-  /** Reduces the reamining requests before internally rate limiting by 1. */
+  /** Reduces the remaining requests before internally rate limiting by 1. */
   decrementRemaining() {
     --this.remaining;
   }

--- a/src/clients/Api/structures/RateLimitCache.js
+++ b/src/clients/Api/structures/RateLimitCache.js
@@ -3,11 +3,11 @@
 const RateLimitMap = require('./RateLimitMap');
 const RateLimit = require('./RateLimit');
 
-// TODO(lando): add a periodic sweep for ratelimits to fix potential memory leak.
+// TODO(lando): add a periodic sweep for rate limits to fix potential memory leak.
 
 /** @typedef {import("./Request")} Request */
 
-/** @typedef {string} RateLimitRequestMeta Combination of request parameters that idenitfy a bucket. */
+/** @typedef {string} RateLimitRequestMeta Combination of request parameters that identify a bucket. */
 /** @typedef {string} RateLimitBucket From Discord - A uid that identifies a group of requests that share a rate limit. */
 /** @typedef {string} RateLimitKey */
 
@@ -27,7 +27,7 @@ const RateLimit = require('./RateLimit');
 module.exports = class RateLimitCache {
   /** Creates a new rate limit cache. */
   constructor() {
-    /** @type {RateLimitMetaToBucket} Request meta values to their associated rate limit bucke; or to `null` if no rate limit for the meta. */
+    /** @type {RateLimitMetaToBucket} Request meta values to their associated rate limit bucket or to `null` if no rate limit for the meta. */
     this.rateLimitMetaToBucket = new Map();
     /** @type {RateLimitMap} Rate limit keys to their associate rate limit. */
     this.rateLimits = new RateLimitMap();
@@ -91,6 +91,8 @@ module.exports = class RateLimitCache {
       }
       return this.createRateLimitFromTemplate(bucket, rateLimitKey);
     }
+
+    return undefined;
   }
 
   /**
@@ -106,6 +108,8 @@ module.exports = class RateLimitCache {
     if (rateLimitTemplate !== undefined) {
       return this.rateLimits.upsert(rateLimitKey, rateLimitTemplate);
     }
+
+    return undefined;
   }
 
   /**
@@ -149,7 +153,7 @@ module.exports = class RateLimitCache {
   /**
    * Runs a request's rate limit meta against the cache to determine if it would trigger a rate limit.
    *
-   * @param {Request} request The request to reference when chacking the rate limit state.
+   * @param {Request} request The request to reference when checking the rate limit state.
    * @returns {boolean} `true` if rate limit would get triggered.
    */
   returnIsRateLimited(request) {

--- a/src/clients/Api/structures/RateLimitMap.js
+++ b/src/clients/Api/structures/RateLimitMap.js
@@ -9,10 +9,6 @@ const RateLimit = require('./RateLimit');
  * @extends Map<string,RateLimit>
  */
 module.exports = class RateLimitMap extends Map {
-  constructor(props) {
-    super(props);
-  }
-
   /**
    * Inserts rate limit if not exists. Otherwise, updates its state.
    *

--- a/src/clients/Api/structures/Request.js
+++ b/src/clients/Api/structures/Request.js
@@ -18,14 +18,14 @@ module.exports = class Request extends BaseRequest {
     super(method, url);
     /** @type {*} Data to send in the body of the request. */
     this.data;
-    /** @type {Object} Addtional headers to send with the request. */
+    /** @type {Object} Additional headers to send with the request. */
     this.headers;
     // /** @type {number} If rate limited, how long in seconds to allow the request to sit in the queue before canceling. */
     // this.timeout;
 
     /** @type {Object<string, any>} If queued, will be the response when this request is sent. */
     this.response;
-    /** @type {number} If queued when using the rate limit rpc service, a timestamp of when the request will first be availble to try again. */
+    /** @type {number} If queued when using the rate limit rpc service, a timestamp of when the request will first be available to try again. */
     this.waitUntil;
 
     Object.assign(this, options);
@@ -45,7 +45,7 @@ module.exports = class Request extends BaseRequest {
   /**
    * Assigns a stricter value to `waitUntil`.
    * Strictness is defined by the value that decreases the chance of getting rate limited.
-   * @param {number} waitUntil A timestamp of when the request will first be availble to try again when queued due to rate limits.
+   * @param {number} waitUntil A timestamp of when the request will first be available to try again when queued due to rate limits.
    */
   assignIfStricterWait(waitUntil) {
     if (this.waitUntil === undefined || this.waitUntil < waitUntil) {

--- a/src/clients/Api/structures/RequestQueue.js
+++ b/src/clients/Api/structures/RequestQueue.js
@@ -30,8 +30,8 @@ module.exports = class RequestQueue {
     /** @type {boolean} Whether or not the `process()` method is already executing. */
     this.processing = false;
     /** @type {import("./Request")[]} The queue. */
-    this.queue = new Array();
-    /** @type The internal value of the length of the queue. */
+    this.queue = [];
+    /** @type {number} The internal value of the length of the queue. */
     this._length = 0;
     /** @type {Api} Api client through which to emit events. */
     this.apiClient = apiClient;
@@ -66,13 +66,13 @@ module.exports = class RequestQueue {
     for (let idx = 0; idx < this.queue.length; ++idx) {
       // undefined = past end of array; null = past end of requests in array (rest are null)
       if (this.queue[idx] === undefined || this.queue[idx] === null) break;
-      if (indices.includes(idx)) continue;
-
-      this.queue[this._length] = this.queue[idx];
-      ++this._length;
+      if (!indices.includes(idx)) {
+        this.queue[this._length] = this.queue[idx];
+        ++this._length;
+      }
     }
 
-    // Assigns `null` to the remaning indices.
+    // Assigns `null` to the remaining indices.
     for (let idx = this._length; idx < this.queue.length; ++idx) {
       if (this.queue[idx] === undefined || this.queue[idx] === null) break;
 

--- a/src/clients/Gateway/Gateway.js
+++ b/src/clients/Gateway/Gateway.js
@@ -572,7 +572,7 @@ module.exports = class Gateway {
   }
 
   /**
-   * Unsets heartbeat values and clears the heartbeatinterval.
+   * Clears heartbeat values and clears the heartbeatinterval.
    * @private
    */
   clearHeartbeat() {
@@ -649,7 +649,7 @@ module.exports = class Gateway {
   }
 
   /**
-   * Handes "Resumed" packet from Discord. https://discordapp.com/developers/docs/topics/gateway#resumed
+   * Handles "Resumed" packet from Discord. https://discordapp.com/developers/docs/topics/gateway#resumed
    * @private
    */
   handleResumed() {
@@ -920,11 +920,11 @@ module.exports = class Gateway {
   }
 
   /**
-   * Returns whether or not the message to be sent will exceed the ratelimit or not, taking into account padded buffers for high priority packets (e.g. heartbeats, resumes).
+   * Returns whether or not the message to be sent will exceed the rate limit or not, taking into account padded buffers for high priority packets (e.g. heartbeats, resumes).
    * @private
    *
    * @param {number} op Op code of the message to be sent.
-   * @returns {boolean} true if sending message won't exceed ratelimit or padding; false if it will
+   * @returns {boolean} true if sending message won't exceed rate limit or padding; false if it will
    */
   canSendPacket(op) {
     const now = new Date().getTime();

--- a/src/clients/Gateway/structures/Identity.js
+++ b/src/clients/Gateway/structures/Identity.js
@@ -3,7 +3,7 @@
 /**  A container of information for identifying with the gateway. https://discordapp.com/developers/docs/topics/gateway#identify-identify-structure */
 module.exports = class Identity {
   /**
-   * Creates a new Identity object for use wuth the gateway.
+   * Creates a new Identity object for use with the gateway.
    *
    * @param {string} token Bot token.
    * @param {void|Object<string, any>} [identity] Properties to add to this identity.

--- a/src/clients/Paracord/Paracord.js
+++ b/src/clients/Paracord/Paracord.js
@@ -10,12 +10,12 @@ const {
   MINUTE_IN_MILLISECONDS,
   LOG_LEVELS,
   LOG_SOURCES,
-  PARARCORDSWEEPINTERVAL,
+  PARACORD_SWEEP_INTERVAL,
 } = require('../../utils/constants');
 
-const { PARACORD_SHARDIDS, PARACORD_SHARDCOUNT } = process.env;
+const { PARACORD_SHARD_IDS, PARACORD_SHARD_COUNT } = process.env;
 
-/* "Start up" refers to logging in to the gateway and waiting for all the guilds to be returned. By default, events will be surpressed during start up. */
+/* "Start up" refers to logging in to the gateway and waiting for all the guilds to be returned. By default, events will be suppressed during start up. */
 
 /**
  * A client that provides caching and limited helper functions. Integrates the Api and Gateway clients into a seamless experience.
@@ -234,9 +234,9 @@ module.exports = class Paracord extends EventEmitter {
       this.init();
     }
 
-    if (PARACORD_SHARDIDS !== undefined) {
-      options.shards = PARACORD_SHARDIDS.split(',');
-      options.shardCount = PARACORD_SHARDCOUNT;
+    if (PARACORD_SHARD_IDS !== undefined) {
+      options.shards = PARACORD_SHARD_IDS.split(',');
+      options.shardCount = PARACORD_SHARD_COUNT;
       const message = `Injecting shard settings from shard launcher. Shard Ids: ${options.shards}. Shard count: ${options.shardCount}`;
       this.log('INFO', message);
     }
@@ -351,7 +351,7 @@ module.exports = class Paracord extends EventEmitter {
    */
   async computeShards(shards, shardCount) {
     if (shards !== undefined && shardCount === undefined) {
-      throw Error('shards defined with no shardcount.');
+      throw Error('shards defined with no shardCount.');
     }
 
     if (shardCount === undefined) {
@@ -386,7 +386,7 @@ module.exports = class Paracord extends EventEmitter {
 
     this.sweepOldUpdatesInterval = setInterval(
       this.sweepOldUpdates,
-      PARARCORDSWEEPINTERVAL,
+      PARACORD_SWEEP_INTERVAL,
     );
   }
 
@@ -626,7 +626,7 @@ module.exports = class Paracord extends EventEmitter {
       this.presences.set(presence.user.id, presence);
     }
 
-    this.circluarAssignCachedUser(presence);
+    this.circularAssignCachedUser(presence);
 
     return presence;
   }
@@ -651,7 +651,7 @@ module.exports = class Paracord extends EventEmitter {
    *
    * @param {Object<string, any>} presence From Discord - https://discordapp.com/developers/docs/topics/gateway#presence-update
    */
-  circluarAssignCachedUser(presence) {
+  circularAssignCachedUser(presence) {
     const cachedUser = this.users.get(presence.user.id);
     if (cachedUser !== undefined) {
       presence.user = cachedUser;
@@ -663,7 +663,7 @@ module.exports = class Paracord extends EventEmitter {
    * Removes presence from cache.
    * @private
    *
-   * @param {string} userId Id of ther presence's user.
+   * @param {string} userId Id of the presence's user.
    */
   deletePresence(userId) {
     this.presences.delete(userId);

--- a/src/clients/Paracord/ShardLauncher.js
+++ b/src/clients/Paracord/ShardLauncher.js
@@ -164,8 +164,8 @@ module.exports = class ShardLauncher {
     const shardIdsCsv = shardIds.join(',');
     const paracordEnv = {
       PARACORD_TOKEN: this.token,
-      PARACORD_SHARDCOUNT: shardCount,
-      PARACORD_SHARDIDS: shardIdsCsv,
+      PARACORD_SHARD_COUNT: shardCount,
+      PARACORD_SHARD_IDS: shardIdsCsv,
     };
 
     const pm2Config = {

--- a/src/clients/Paracord/eventFuncs.js
+++ b/src/clients/Paracord/eventFuncs.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Gateway = require('../Gateway');
 const { SECOND_IN_MILLISECONDS } = require('../../utils/constants');
 
 const Guild = require('./structures/Guild');
@@ -9,7 +8,7 @@ const {
   CHANNEL_TYPES,
 } = require('../../utils/constants');
 
-/** The methods in ALL_CAPS correspond to a Discord gateway event (https://discordapp.com/developers/docs/topics/gateway#commands-and-events-gateway-events) and are called in the Pararcord `.eventHandler()` method. */
+/** The methods in ALL_CAPS correspond to a Discord gateway event (https://discordapp.com/developers/docs/topics/gateway#commands-and-events-gateway-events) and are called in the Paracord `.eventHandler()` method. */
 
 /**
  * @private

--- a/src/clients/Paracord/eventFuncs.js
+++ b/src/clients/Paracord/eventFuncs.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Gateway = require('../Gateway');
 const { SECOND_IN_MILLISECONDS } = require('../../utils/constants');
 
 const Guild = require('./structures/Guild');
@@ -322,8 +323,9 @@ exports.GATEWAY_CLOSE = function GATEWAY_CLOSE({ shouldReconnect, gateway }) {
   if (shouldReconnect) {
     this.gatewayLoginQueue.push(gateway);
 
-    if (gateway.shard === this.startingShard) {
-      this.startingShard = null;
+    if (gateway.shard === this.startingGateway.shard) {
+      this.startingGateway.releaseIdentifyLocks();
+      this.startingGateway = null;
     }
   }
 };

--- a/src/rpc/protobufs/request.proto
+++ b/src/rpc/protobufs/request.proto
@@ -8,7 +8,7 @@ service RequestService {
 /* Request represents a client's Discord API request.
  * It contains the necessary information for the server to make the request on its behalf. */
 message RequestMessage {
-    string method = 1; // HHTP method
+    string method = 1; // HTTP method
     string url = 2; // Discord endpoint url. (e.g. channels/123)
     string data = 3; // JSON encoded data to send wtih request.
     string headers = 4; // JSON encoded headers to send with request.

--- a/src/rpc/server/Server.js
+++ b/src/rpc/server/Server.js
@@ -72,7 +72,13 @@ module.exports = class Server extends grpc.Server {
    */
   createDefaultBindArgs() {
     const callback = () => {
-      this.start();
+      try {
+        this.start();
+      } catch (err) {
+        if (err.message === 'server must be bound in order to start') {
+          console.error('server must be bound in order to start. maybe this host:port is already bound?');
+        }
+      }
 
       const message = `Rpc server running at http://${this.host}:${this.port}`;
       this.emit('DEBUG', {
@@ -118,7 +124,7 @@ module.exports = class Server extends grpc.Server {
     });
   }
 
-  /** Adds the identify lock service to this erver. Allows the server to maintain a lock for clients. */
+  /** Adds the identify lock service to this server. Allows the server to maintain a lock for clients. */
   addLockService() {
     this.identifyLock = new Lock(this.emitter);
 
@@ -147,7 +153,7 @@ module.exports = class Server extends grpc.Server {
     });
   }
 
-  /** Start the cserver. */
+  /** Start the server. */
   serve() {
     this.bindAsync(...this.bindArgs);
   }

--- a/src/rpc/server/Server.js
+++ b/src/rpc/server/Server.js
@@ -36,7 +36,7 @@ module.exports = class Server extends grpc.Server {
     super();
     /** @type {import("events").EventEmitter} Emitter for debug logging. */
     this.emitter;
-    /** @type {RpcServerBindArgs} Argumenets passed when binding the server to its port. */
+    /** @type {RpcServerBindArgs} Arguments passed when binding the server to its port. */
     this.bindArgs;
 
     /** @type {void|Api} Api client when the "request" service is added. */

--- a/src/rpc/services/request/RequestService.js
+++ b/src/rpc/services/request/RequestService.js
@@ -21,7 +21,7 @@ module.exports = class RequestService extends definition.RequestService {
     this.target = defaultArgs[0];
   }
 
-  /** Sends to the server the information to make a request to Discord. returning a promise with the response.
+  /** Sends the information to make a request to Discord to the server. returning a promise with the response.
    *
    * @param {string} method HTTP method of the request.
    * @param {string} url Discord endpoint url. (e.g. channels/123)

--- a/src/rpc/structures/identityLock/LockRequestMessage.js
+++ b/src/rpc/structures/identityLock/LockRequestMessage.js
@@ -11,7 +11,7 @@ module.exports = class LockRequestMessage {
   constructor(timeOut, token) {
     /** @type {number} How long in ms the server should wait before expiring the lock. */
     this.timeOut = timeOut;
-    /** @type {string|void} Unique ID given to the last client to acquire the lock. */
+    /** @type {string|void} Unique ID given to the last client that acquired the lock. */
     this.token = token;
   }
 

--- a/src/rpc/structures/request/RequestMessage.js
+++ b/src/rpc/structures/request/RequestMessage.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/** A class for the ReequestMessage protobuf */
+/** A class for the RequestMessage protobuf */
 module.exports = class RequestMessage {
   /**
    * Create a new RequestMessage sent from client to server.

--- a/src/rpc/structures/request/ResponseMessage.js
+++ b/src/rpc/structures/request/ResponseMessage.js
@@ -6,7 +6,7 @@ module.exports = class ResponseMessage {
    * Creates a new ResponseMessage send from server to client.
    *
    * @param {number} status The HTTP status code of the response.
-   * @param {string} statuxText Status mssage returned by the server. (e.g. "OK" with a 200 status)
+   * @param {string} statusText Status message returned by the server. (e.g. "OK" with a 200 status)
    * @param {*} data The data returned by Discord.
    */
   constructor(status, statusText, data) {

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -6,6 +6,8 @@
 
 /** @typedef {import("./rpc/services/request/RequestService")} RequestService */
 
+/** @typedef {import("./rpc/services/identifyLock/IdentifyLockService")} IdentifyLockService */
+
 /** @typedef {import("./clients/Api/structures/RateLimit")} RateLimit */
 
 /** @typedef {import("./clients/Api/structures/RateLimitCache")} RateLimitCache */
@@ -33,7 +35,7 @@
 /**
  * @typedef ApiOptions Optional parameters for this api handler.
  *
- * @property {import("events").EventEmitter} [emitter] Event emitter through which to emite debug and warning events.
+ * @property {import("events").EventEmitter} [emitter] Event emitter through which to emit debug and warning events.
  */
 
 /**
@@ -79,14 +81,12 @@
 
 /** @typedef {[number, number]} Shard [ShardID, ShardCount] to identify with. https://discordapp.com/developers/docs/topics/gateway#identify-identify-structure */
 
- /**
- * @typedef ParacordLoginOptions Optional parameters for Paracord's login method.
- * 
- * @param {Object<string, any>} [identity] An object containing information for identifying with the gateway. https://discordapp.com/developers/docs/topics/gateway#identify-identify-structure
- * @property {number[]} [shards] Shards to spawn internally.
- * @property {number} [shardCount] The total number of shards that will be handled by the bot.
- * @property {boolean} [allowEventsDuringStartup=false] During startup, if events should be emitted before `PARACORD_STARTUP_COMPLETE` is emitted. `GUILD_CREATE` events will never be emitted during start up.
- */
+/**
+  * @typedef GatewayLockServerOptions
+  *
+  * @property  {void|ServerOptions} mainServerOptions Options for connecting this service to the identifylock server. Will not be released except by time out. Best used for global minimum wait time. Pass `null` to ignore.
+   * @property  {ServerOptions} [serverOptions] Options for connecting this service to the identifylock server. Will be acquired and released in order.
+  */
 
 // Paracord
 
@@ -98,9 +98,18 @@
  * @property {GatewayOptions} [gatewayOptions]
  */
 
+/**
+ * @typedef ParacordLoginOptions Optional parameters for Paracord's login method.
+ *
+ * @param {Object<string, any>} [identity] An object containing information for identifying with the gateway. https://discordapp.com/developers/docs/topics/gateway#identify-identify-structure
+ * @property {number[]} [shards] Shards to spawn internally.
+ * @property {number} [shardCount] The total number of shards that will be handled by the bot.
+ * @property {boolean} [allowEventsDuringStartup=false] During startup, if events should be emitted before `PARACORD_STARTUP_COMPLETE` is emitted. `GUILD_CREATE` events will never be emitted during start up.
+ */
+
 // Shard Launcher
 
- /**
+/**
  * @typedef ShardLauncherOptions
  * @property {string} [token] Discord token. Used to find recommended shard count when no `shardIds` provided. Will be coerced into a bot token.
  * @property {InternalShardIds} [shardIds] Ids of the shards to start internally. Ignored if `shardChunks` is defined.
@@ -159,7 +168,7 @@
  *
  * @property {boolean} success true, the operation was a success; false, the operation failed.
  * @property {string} message Reason for the failed operation.
- * @property {stirng} token Unique ID given to the last client to acquire the lock.
+ * @property {string} token Unique ID given to the last client to acquire the lock.
  */
 
 /**

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -208,7 +208,7 @@ module.exports = class Util {
   }
 
   /**
-   * Appends a user's username to their descriminator in a common format.
+   * Appends a user's username to their discriminator in a common format.
    *
    * @param {Object<string, any>} user
    */
@@ -239,6 +239,7 @@ module.exports = class Util {
   static uuid() {
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
       const r = (Math.random() * 16) | 0;
+      /* eslint-disable-next-line eqeqeq */
       const v = c == 'x' ? r : (r & 0x3) | 0x8;
       return v.toString(16);
     });

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -61,7 +61,7 @@ module.exports = {
   /** Discord epoch (2015-01-01T00:00:00.000Z) */
   DISCORD_EPOCH: 1420070400000,
   DISCORD_CDN_URL: 'https://cdn.discordapp.com/',
-  PARACORD_UPDATE_USER_WAIT_MILLISECONDS: 500,
+  PARACORD_SWEEP_INTERVAL: 500,
   /** A permissions map for operations relevant to the library. */
   PERMISSIONS: {
     ADMINISTRATOR: 0x8,


### PR DESCRIPTION
- Change some eslint errors to warnings.
- Add 'ws' to package.json
- Adjust gateway identify locking to accept an arbitrary number of locks
- Add state properties to identify lock service instances
- Resurface gateway identify lock service function to Paracord
- Set Paracord client to release locks in certain circumstances
- Added helpful error message to server on host:port conflict
- Clean up typos and other miscellaneous tasks